### PR TITLE
UI tweaks: language switcher reachability, cursor pointer, border color

### DIFF
--- a/components/footer/Footer.css
+++ b/components/footer/Footer.css
@@ -79,6 +79,7 @@
 				text-decoration: none;
 				color: var(--_fo-text-primary);
 				transition: color 0.1s, transform 0.1s;
+				cursor: pointer;
 				&:hover {
 					color: var(--_fo-link-color);
 				}

--- a/components/header/Header.css
+++ b/components/header/Header.css
@@ -166,7 +166,7 @@
 		}
 		&>.content {
 			display: flex;
-			flex-wrap: wrap;
+			flex-wrap: nowrap;
 			flex: 1;
 			overflow: hidden;
 			gap: 20px;

--- a/components/header/Header.tsx
+++ b/components/header/Header.tsx
@@ -146,12 +146,16 @@ export class HeaderWrapper extends Component<HeaderOptions & { stylesheet?: URL 
 	}
 
 	private listenForOverflow() {
-		function isOverflowing(container: HTMLElement) {
-			return container.scrollWidth > container.offsetWidth;
+		function isOverflowing(container1: HTMLElement, container2: HTMLElement, wrapper: HTMLElement, gap: number) {
+			return container1.scrollWidth + container2.scrollWidth + gap > wrapper.offsetWidth;
 		}
 		const left = this.content.querySelector('.left') as HTMLDivElement;
+		const right = this.content.querySelector('.right') as HTMLDivElement;
+		const content = this.content;
+		const gap = parseFloat(getComputedStyle(content).columnGap) || 0;
+
 		const onResize = () =>
-			this.header.classList.toggle('compact', isOverflowing(left));
+			this.header.classList.toggle('compact', isOverflowing(left, right, content, gap));
 		const observer = new ResizeObserver(() => onResize());
 		observer.observe(this.content);
 		onResize();

--- a/theme/unyt.css
+++ b/theme/unyt.css
@@ -39,7 +39,7 @@
 	/* border */
 	--unyt-dark-border-primary: hsla(0, 0%, 100%, .1);
 	--unyt-light-border-primary: hsla(0, 0%, 0%, 0.1);
-	--unyt-dark-border-invalid: rgb(215, 26, 26);
+	--unyt-dark-border-invalid: rgb(244, 126, 126);
 	--unyt-light-border-invalid: rgb(215, 26, 26);
 }
 


### PR DESCRIPTION
Collection PR with three UI fixes.

## Language switcher unreachable between breakpoints

When shrinking the header, the right container (holding the language switcher) disappeared noticeably earlier than the left one. In the gap between, neither the language switcher was visible nor the burger menu active, so switching the language was not possible.

Cause: `.content` had `flex-wrap: wrap`. When space got tight, `.right` moved into a second row and was cut off by the header's `overflow: hidden`, long before `listenForOverflow` triggered the `.compact` mode. The switch point was also language dependent, because it only measured the overflow of `.left`.

Fix: `flex-wrap: nowrap` on `.content` so nothing wraps anymore. In addition, `listenForOverflow` now measures the combined width of `.left` and `.right` (including the gap) against the available width, instead of only `.left`. This way the header switches to burger mode as soon as both containers no longer fit together.

**Note:** I could only reproduce and verify this in Chrome DevTools, not locally in the running component. The change to `listenForOverflow` is therefore untested in the real component context. Please keep that in mind during review and do not merge that part if in doubt.

Two things I noticed but deliberately left untouched: `.left` still has `width: 100%` next to `flex: 1`, and the `@media (max-width: 640px)` query might be partly redundant now due to the new measurement.

## Cursor pointer on scroll-to-top link

Added missing `cursor: pointer` on the scroll-to-top arrow in the footer, so it is immediately recognizable as clickable.

## Invalid border color in dark mode

Gave the invalid input border color a better contrast for improved visibility.